### PR TITLE
Feature/mi v2 edit partition key

### DIFF
--- a/ffc-ahwr-mi-reporting/mi-report-v2/transformJsonToCsv.js
+++ b/ffc-ahwr-mi-reporting/mi-report-v2/transformJsonToCsv.js
@@ -20,7 +20,7 @@ const transformJsonToCsv = (events) => {
 
 function transformEventToCsv (event) {
   const { partitionKey, SessionId: sessionId, Status: eventStatus } = event
-  const sbiFromPartitionKey = partitionKey && partitionKey.length > 9 ? partitionKey.slice(0, 8) : partitionKey
+  const sbiFromPartitionKey = partitionKey && partitionKey.length > 9 ? partitionKey.slice(0, 9) : partitionKey
   let parsePayload = ''
   try {
     parsePayload = JSON.parse(event.Payload)

--- a/ffc-ahwr-mi-reporting/mi-report-v2/transformJsonToCsv.js
+++ b/ffc-ahwr-mi-reporting/mi-report-v2/transformJsonToCsv.js
@@ -19,8 +19,8 @@ const transformJsonToCsv = (events) => {
 }
 
 function transformEventToCsv (event) {
-  const { partitionKey: sbiFromPartitionKey, SessionId: sessionId, Status: eventStatus } = event
-
+  const { partitionKey, SessionId: sessionId, Status: eventStatus } = event
+  const sbiFromPartitionKey = partitionKey && partitionKey.length > 9 ? partitionKey.slice(0, 8) : partitionKey
   let parsePayload = ''
   try {
     parsePayload = JSON.parse(event.Payload)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ffc-ahwr-mi-reporting",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ffc-ahwr-mi-reporting",
-      "version": "0.9.7",
+      "version": "0.9.8",
       "dependencies": {
         "@azure/ai-form-recognizer": "^4.0.0",
         "@azure/data-tables": "13.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ffc-ahwr-mi-reporting",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Azure Function to create MI reports",
   "author": "Defra",
   "contributors": [

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
-sonar.javascript.exclusions=**/jest.*.js,**/__mocks__/**,**/node_modules/**
+sonar.javascript.exclusions=**/jest.*.js,**/__mocks__/**,**/node_modules/**,**/test/**,**/test-output/**
 sonar.javascript.lcov.reportPaths=test-output/lcov.info
 sonar.exclusions=/test/**,**/*.test.js,*snyk_report.html

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -115,10 +115,4 @@ describe('report', () => {
     expect(mockWriteFile).toHaveBeenCalled()
     expect(MOCK_UPLOAD_FILE).toBeCalledTimes(2)
   })
-
-  test('should not upload files when write file to share', async () => {
-    await generateReport(mockContext, mockTimer)
-    expect(mockWriteFile).toHaveBeenCalled()
-    expect(MOCK_UPLOAD_FILE).toBeCalledTimes(2)
-  })
 })

--- a/test/unit/mi-report-v2/transformJsonToCsv.test.js
+++ b/test/unit/mi-report-v2/transformJsonToCsv.test.js
@@ -118,3 +118,21 @@ describe('events are transformed to remove json structure', () => {
     expect(result).toContain(expectedTransformedJsonExample4)
   })
 })
+
+describe('partition Key is transformed to 9 characters for sbi', () => {
+  test('csv content includes correct sbi from event partition key when exactly 9 characters', () => {
+    events[0].partitionKey = '123456789'
+    result = transformJsonToCsv(events)
+
+    expect(result).toContain('123456789')
+  })
+
+  test('csv content includes correct sbi from event partition key when more than 9 characters', () => {
+    events[0].partitionKey = '12345678999999'
+    result = transformJsonToCsv(events)
+    console.log('result', result)
+
+    expect(result).toContain('123456789')
+    expect(result).not.toContain('12345678999999')
+  })
+})


### PR DESCRIPTION
## Description of changes

Added check to limit partition key to 9 characters so it always properly represents the SBI number in V2 file generation.

## Checklist

<!-- [x] if you have completed the task -->
<!-- [n/a] if the task is not relevant -->

- [x] Content has no typos
- [x] Correct inline validation errors
- [x] Removed all unnecessary console logs
- [x] Removed all commented out code
- [n/a] Updated README / confluence